### PR TITLE
Add support of flat playlist

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,7 @@ impl StdError for Error {
 pub struct YoutubeDl {
     youtube_dl_path: Option<PathBuf>,
     format: Option<String>,
+    flat_playlist: bool,
     socket_timeout: Option<String>,
     all_formats: bool,
     auth: Option<(String, String)>,
@@ -113,6 +114,7 @@ impl YoutubeDl {
             url: url.into(),
             youtube_dl_path: None,
             format: None,
+            flat_playlist: false,
             socket_timeout: None,
             all_formats: false,
             auth: None,
@@ -130,6 +132,12 @@ impl YoutubeDl {
     /// Set the `-F` command line option.
     pub fn format<S: Into<String>>(&mut self, format: S) -> &mut Self {
         self.format = Some(format.into());
+        self
+    }
+
+    /// Set the `--flat-playlist` command line flag.
+    pub fn flat_playlist(&mut self, flat_playlist: bool) -> &mut Self {
+        self.flat_playlist = flat_playlist;
         self
     }
 
@@ -175,6 +183,10 @@ impl YoutubeDl {
         if let Some(format) = &self.format {
             args.push("-f");
             args.push(format);
+        }
+
+        if self.flat_playlist {
+            args.push("--flat-playlist");
         }
 
         if let Some(timeout) = &self.socket_timeout {


### PR DESCRIPTION
By setting this parameter to true, fetching info about playlist will be speed up for big playlists. But most of values will be None because there is no info about each video in this playlist.

I'm new in Rust, and this code maybe not so good. Sorry about this.