### PR TITLE
Add custom parser for format codec fields

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -478,4 +478,22 @@ mod tests {
 
         assert_eq!(output.season_number, Some(2));
     }
+
+    #[test]
+    fn correct_format_codec_parsing() {
+        let output = YoutubeDl::new("https://www.youtube.com/watch?v=WhWc3b3KhnY")
+            .run()
+            .unwrap()
+            .to_single_video();
+
+        let mut none_counter = 0;
+        for format in output.formats.unwrap() {
+            assert_ne!(Some("none".to_string()), format.acodec);
+            assert_ne!(Some("none".to_string()), format.vcodec);
+            if format.acodec.is_none() || format.vcodec.is_none() {
+                none_counter += 1;
+            }
+        }
+        assert!(none_counter > 0);
+    }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -28,6 +28,7 @@ pub struct Comment {
 #[derive(Clone, Serialize, Deserialize, Debug, Default)]
 pub struct Format {
     pub abr: Option<f64>,
+    #[serde(deserialize_with = "parse_codec")]
     pub acodec: Option<String>,
     pub asr: Option<f64>,
     pub container: Option<String>,
@@ -57,8 +58,22 @@ pub struct Format {
     pub tbr: Option<f64>,
     pub url: Option<String>,
     pub vbr: Option<f64>,
+    #[serde(deserialize_with = "parse_codec")]
     pub vcodec: Option<String>,
     pub width: Option<i64>,
+}
+
+// Codec values are set explicitly, and when there is no codec, it is given as "none".
+// Default decoding in this case would result in `Some("none".to_string())`, which is why
+// this custom parse function exists.
+fn parse_codec<'de, D>(d: D) -> Result<Option<String>, D::Error>
+where
+    D: serde::de::Deserializer<'de>,
+{
+    serde::de::Deserialize::deserialize(d).map(|x: Option<_>| match x.unwrap_or_default() {
+        Some(ref s) if s == "none" => None,
+        x => x,
+    })
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, Default)]


### PR DESCRIPTION
This adds a custom function that parses the codec fields as one would expect.

Closes #10 