### PR TITLE
Filesize can be a float

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -34,7 +34,7 @@ pub struct Format {
     pub container: Option<String>,
     pub downloader_options: Option<BTreeMap<String, Value>>,
     pub ext: Option<String>,
-    pub filesize: Option<i64>,
+    pub filesize: Option<f64>,
     pub filesize_approx: Option<String>,
     pub format: Option<String>,
     pub format_id: Option<String>,


### PR DESCRIPTION
Sometimes youtube-dl gives us a more-precise filesize.