### PR TITLE
Update docs for format's arg name

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -259,7 +259,7 @@ impl YoutubeDl {
         self
     }
 
-    /// Set the `-F` command line option.
+    /// Set the `-f` command line option.
     pub fn format<S: Into<String>>(&mut self, format: S) -> &mut Self {
         self.format = Some(format.into());
         self


### PR DESCRIPTION
Trues up the docstring to show that `format` inserts a `-f` into the `youtube-dl` invocation to select a format, not `-F` which lists formats.