### PR TITLE
Add feature `yt-dlp` to support yt-dlp

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,11 @@ homepage = "https://github.com/GyrosOfWar/youtube-dl-rs"
 categories = ["multimedia::video"]
 keywords = ["youtube-dl", "youtube"]
 
+[features]
+default = ["youtube-dl"]
+youtube-dl = []
+yt-dlp = []
+
 [dependencies]
 serde = { version = "1.0.124", features = ["derive"] }
 serde_json = "1.0.64"

--- a/src/model.rs
+++ b/src/model.rs
@@ -35,7 +35,10 @@ pub struct Format {
     pub downloader_options: Option<BTreeMap<String, Value>>,
     pub ext: Option<String>,
     pub filesize: Option<f64>,
+    #[cfg(feature = "youtube-dl")]
     pub filesize_approx: Option<String>,
+    #[cfg(feature = "yt-dlp")]
+    pub filesize_approx: Option<f64>,
     pub format: Option<String>,
     pub format_id: Option<String>,
     pub format_note: Option<String>,
@@ -209,7 +212,10 @@ pub struct SingleVideo {
     pub extractor: Option<String>,
     pub extractor_key: Option<String>,
     pub filesize: Option<i64>,
+    #[cfg(feature = "youtube-dl")]
     pub filesize_approx: Option<String>,
+    #[cfg(feature = "yt-dlp")]
+    pub filesize_approx: Option<f64>,
     pub format: Option<String>,
     pub format_id: Option<String>,
     pub format_note: Option<String>,
@@ -314,4 +320,10 @@ pub enum Protocol {
     M3U8Native,
     #[serde(rename = "http_dash_segments")]
     HttpDashSegments,
+    #[cfg(feature = "yt-dlp")]
+    #[serde(rename = "mhtml")]
+    Mhtml,
+    #[cfg(feature = "yt-dlp")]
+    #[serde(rename = "https+https")]
+    HttpsHttps,
 }


### PR DESCRIPTION
This commit adds support for json emitted from `yt-dlp`, which is only
slightly different from `youtube-dl`. The changes are gated behind the
`yt-dlp` feature.

Youtube-dl recently broke again with ytdl-org/youtube-dl#30363 . Since this crate supports specifying youtube-dl's binary name, yt-dlp can be used as an alternative with these changes