### PR TITLE
Update model for `yt-dlp` 2023.01.02 and newer

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -54,7 +54,10 @@ pub struct Format {
     pub player_url: Option<String>,
     pub preference: Option<Value>,
     pub protocol: Option<Protocol>,
+    #[cfg(feature = "youtube-dl")]
     pub quality: Option<i64>,
+    #[cfg(feature = "yt-dlp")]
+    pub quality: Option<f64>,
     pub resolution: Option<String>,
     pub source_preference: Option<i64>,
     pub stretched_ratio: Option<f64>,


### PR DESCRIPTION
Due to [this commit](https://github.com/yt-dlp/yt-dlp/commit/9bb856998b0d5a0ad58268f0ba8d784fb9d934e3), the `quality` field should now be considered a float when running against `yt-dlp`.

This updates the model to handle this, when the `yt-dlp` feature is active.