### PR TITLE
Add native-tls/rustls-tls features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,4 +38,4 @@ jobs:
         run: cargo check --all-features --all-targets --verbose
 
       - name: Run tests
-        run: cargo hack test --each-feature
+        run: cargo hack test --each-feature --skip-no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,10 @@ categories = ["multimedia::video"]
 keywords = ["youtube-dl", "youtube", "yt-dlp"]
 
 [features]
-default = []
+default = ["native-tls"]
 downloader = ["reqwest", "tokio"]
+native-tls = ["reqwest/native-tls"]
+rustls-tls = ["reqwest/rustls-tls"]
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ serde_json = "1"
 log = "0.4"
 wait-timeout = "0.2"
 tokio = { version = "1", optional = true, features = ["io-util", "process", "time", "fs"] }
-reqwest = { version = "0.11", optional = true, features = ["json"] }
+reqwest = { version = "0.11", optional = true, default-features = false, features = ["json"] }
 
 [dev-dependencies]
 env_logger = "0.10"


### PR DESCRIPTION
With the transition from libssl1 to libssl3 and Ubuntu not shipping libssl1 on 22.04 and not shipping libssl3 on 20.04, linking to native-tls/openssl-sys can be problematic.

You can link statically using openssl vendored or rustls to get around this problem, this pull request adds a feature to use rustls instead of the default native-tls in reqwest.

To use the `rustls` feature
```toml
[dependencies]
youtube_dl = { version = "0.8.0", default-features = false, features = ["rustls-tls"] }
```
or
```toml
[dependencies.youtube_dl]
version = "0.8.0"
default-features = false
features = ["rustls-tls"]
```

To link statically to openssl instead you can include this in your Cargo.toml
```toml
[target.'cfg(unix)'.dependencies]
openssl = { version = "0.10", features = ["vendored"] }
```

If you use Cross to cross compile you may also need to install libssl
```toml
[build]
pre-build = [
    "dpkg --add-architecture $CROSS_DEB_ARCH",
    "apt-get update && apt-get --assume-yes install libssl-dev:$CROSS_DEB_ARCH"
]
```