### PR TITLE
Add ignore_errors to builder and options

### DIFF
--- a/examples/async.rs
+++ b/examples/async.rs
@@ -7,6 +7,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .run_async()
         .await?;
     let title = output.into_single_video().unwrap().title;
-    println!("Video title: {}", title);
+    println!("Video title: {title:?}");
     Ok(())
 }

--- a/examples/downloader.rs
+++ b/examples/downloader.rs
@@ -9,6 +9,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .run_async()
         .await?;
     let title = output.into_single_video().unwrap().title;
-    println!("Video title: {}", title);
+    println!("Video title: {title:?}");
     Ok(())
 }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -6,5 +6,5 @@ fn main() {
         .run()
         .unwrap();
     let title = output.into_single_video().unwrap().title;
-    println!("Video title: {}", title);
+    println!("Video title: {title:?}");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -404,7 +404,7 @@ impl YoutubeDl {
         self.debug = arg;
         self
     }
-    
+
     /// Specify whether to ignore errors (exit code & flag)
     pub fn ignore_errors(&mut self, arg: bool) -> &mut Self {
         self.ignore_errors = arg;
@@ -478,7 +478,7 @@ impl YoutubeDl {
             args.push("-P");
             args.push(output_dir);
         }
-        
+
         if self.ignore_errors {
             args.push("--ignore-errors");
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -260,6 +260,7 @@ pub struct YoutubeDl {
     output_template: Option<String>,
     output_directory: Option<String>,
     debug: bool,
+    ignore_errors: bool,
 }
 
 impl YoutubeDl {
@@ -284,6 +285,7 @@ impl YoutubeDl {
             output_template: None,
             output_directory: None,
             debug: false,
+            ignore_errors: false,
         }
     }
 
@@ -402,6 +404,12 @@ impl YoutubeDl {
         self.debug = arg;
         self
     }
+    
+    /// Specify whether to ignore errors (exit code & flag)
+    pub fn ignore_errors(&mut self, arg: bool) -> &mut Self {
+        self.ignore_errors = arg;
+        self
+    }
 
     fn path(&self) -> &Path {
         match &self.youtube_dl_path {
@@ -470,6 +478,10 @@ impl YoutubeDl {
             args.push("-P");
             args.push(output_dir);
         }
+        
+        if self.ignore_errors {
+            args.push("--ignore-errors");
+        }
 
         for extra_arg in &self.extra_args {
             args.push(extra_arg);
@@ -521,7 +533,7 @@ impl YoutubeDl {
             child.wait()?
         };
 
-        if exit_code.success() {
+        if exit_code.success() || self.ignore_errors {
             if self.debug {
                 let string = std::str::from_utf8(&stdout).expect("invalid utf-8 output");
                 eprintln!("{}", string);
@@ -585,7 +597,7 @@ impl YoutubeDl {
             child.wait().await?
         };
 
-        if exit_code.success() {
+        if exit_code.success() || self.ignore_errors {
             if self.debug {
                 let string = std::str::from_utf8(&stdout).expect("invalid utf-8 output");
                 eprintln!("{}", string);

--- a/src/model.rs
+++ b/src/model.rs
@@ -248,7 +248,7 @@ pub struct SingleVideo {
     pub thumbnail: Option<String>,
     pub thumbnails: Option<Vec<Thumbnail>>,
     pub timestamp: Option<f64>,
-    pub title: String,
+    pub title: Option<String>,
     pub track: Option<String>,
     pub track_id: Option<String>,
     pub track_number: Option<String>,

--- a/src/model.rs
+++ b/src/model.rs
@@ -146,7 +146,7 @@ pub struct JsonOutput {
 
 #[derive(Clone, Serialize, Deserialize, Debug, Default)]
 pub struct Playlist {
-    pub entries: Option<Vec<SingleVideo>>,
+    pub entries: Option<Vec<Option<SingleVideo>>>,
     pub extractor: Option<String>,
     pub extractor_key: Option<String>,
     pub id: Option<String>,

--- a/src/model.rs
+++ b/src/model.rs
@@ -146,7 +146,8 @@ pub struct JsonOutput {
 
 #[derive(Clone, Serialize, Deserialize, Debug, Default)]
 pub struct Playlist {
-    pub entries: Option<Vec<Option<SingleVideo>>>,
+    #[serde(default, deserialize_with = "parse_entries")]
+    pub entries: Option<Vec<SingleVideo>>,
     pub extractor: Option<String>,
     pub extractor_key: Option<String>,
     pub id: Option<String>,
@@ -321,12 +322,25 @@ pub enum Protocol {
 // given as "none" (instead of simply missing from the JSON).
 // Default decoding in this case would result in `Some("none".to_string())`, which is why
 // this custom parse function exists.
-fn parse_codec<'de, D>(d: D) -> Result<Option<String>, D::Error>
+fn parse_codec<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
 where
     D: Deserializer<'de>,
 {
-    Deserialize::deserialize(d).map(|x: Option<_>| match x.unwrap_or_default() {
+    Deserialize::deserialize(deserializer).map(|x: Option<_>| match x.unwrap_or_default() {
         Some(s) if s == "none" => None,
         x => x,
     })
+}
+
+// Video entries can be null in the case of premium videos
+// Flattens entries to simplify the type from Option<Vec<Option<SingleVideo>>>> to Option<Vec<SingleVideo>>
+fn parse_entries<'de, D>(deserializer: D) -> Result<Option<Vec<SingleVideo>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let entries: Option<Vec<Option<SingleVideo>>> = Deserialize::deserialize(deserializer)?;
+    let flattened_entries = entries
+        .map(|vec_option_single_video| vec_option_single_video.into_iter().flatten().collect());
+
+    Ok(flattened_entries)
 }


### PR DESCRIPTION
This solves #40

Technically enabling `--ignore-errors` is useless as that's the default behavior with yt-dlp, but not with youtube_dl, but this skips the exit code check, as any stdout will result in an exit code of 1.