### PR TITLE
Added new protocol to enum : m3u8_native+https

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -318,6 +318,8 @@ pub enum Protocol {
     M3U8NativeM3U8Native,
     #[serde(rename = "niconico_dmc")]
     NicoNicoDmc,
+    #[serde(rename = "m3u8_native+https")]
+    M3U8NativeHttps,
 }
 
 // Codec values are set explicitly, and when there is no codec, it is sometimes


### PR DESCRIPTION
while trying to download this video: https://www.youtube.com/watch?v=MoKe4zvtNzA 
Serde panicked with the unknown variant 'm3u8_native+https' I added it to the protocol enum