### PR TITLE
Added additional build flags

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -367,14 +367,12 @@ impl YoutubeDl {
     /// Set the `--datebefore` flag only downloading/viewing videos on or before this date
     pub fn date_before<S: Into<String>>(&mut self, date_string: S) -> &mut Self {
         self.date_before = Some(date_string.into());
-        self.ignore_error_101 = true;
         self
     }
     
     /// Set the `--dateafter` flag only downloading/viewing vidieos on or after this date 
     pub fn date_after<S: Into<String>>(&mut self, date_string: S) -> &mut Self {
         self.date_after = Some(date_string.into());
-        self.ignore_error_101 = true;
         self
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -670,7 +670,7 @@ impl YoutubeDl {
             child.wait().await?
         };
 
-        if exit_code.success() || self.ignore_errors {
+        if exit_code.success() || self.ignore_errors || (self.ignore_error_101 && exit_code.code() == Some(101)) {
             if self.debug {
                 let string = std::str::from_utf8(&stdout).expect("invalid utf-8 output");
                 eprintln!("{}", string);


### PR DESCRIPTION
Added support for the following option flags during build: 
. --break-on-reject
 . --playlist-reverse
 . --datebefore
 . --dateafter
 . --date
As well as conditional support for ignoring error code 101 which often coincides with the use of break-on-reject.