### PR TITLE
feat: Allow downloading videos to specified destination without parsing JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - BREAKING CHANGE: Split `downloader` feature flag into two (`downloader-native-tls` and `downloader-rustls-tls`)
 - feat: Add support for `heatmap` output data
 - feat: Added new protocol to enum: `m3u8_native+https` and a fallback value in case none of the variants match.
-- feat: Added additional yt-dlp flags (playlist_reverse, date, dateafter, datebefore)
+- feat: Added additional yt-dlp flags (`playlist_reverse`, `date`, `dateafter`, `datebefore`)
 
 # 0.8.1
 - feat: add support for `rustls-tls` feature of the transitive reqwest dependency

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - feat: Add additional yt-dlp flags (`playlist_reverse`, `date`, `dateafter`, `datebefore`)
 - feat: Add new methods `download_to` and `download_to_async` to just download the video(s) to a destination.
 - feat: Add new methods `run_raw` and `run_raw_async` to get the JSON output as `serde_json::Value`
+- BREAKING CHANGE: Removed `download()` method on `YoutubeDl`, replaced with `download_to()` and `download_to_async()`
 
 # 0.8.1
 - feat: add support for `rustls-tls` feature of the transitive reqwest dependency

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,10 @@
 - fix: Add niconico_dmc to formats
 - BREAKING CHANGE: Split `downloader` feature flag into two (`downloader-native-tls` and `downloader-rustls-tls`)
 - feat: Add support for `heatmap` output data
-- feat: Added new protocol to enum: `m3u8_native+https` and a fallback value in case none of the variants match.
-- feat: Added additional yt-dlp flags (`playlist_reverse`, `date`, `dateafter`, `datebefore`)
+- feat: Add new protocol to enum: `m3u8_native+https` and a fallback value in case none of the variants match.
+- feat: Add additional yt-dlp flags (`playlist_reverse`, `date`, `dateafter`, `datebefore`)
+- feat: Add new methods `download_to` and `download_to_async` to just download the video(s) to a destination.
+- feat: Add new methods `run_raw` and `run_raw_async` to get the JSON output as `serde_json::Value`
 
 # 0.8.1
 - feat: add support for `rustls-tls` feature of the transitive reqwest dependency

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ required-features = ["tokio"]
 
 [[example]]
 name = "downloader"
-required-features = ["downloader"]
+required-features = ["downloader-rustls-tls"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "youtube_dl"
-version = "0.8.1"
+version = "0.9.0-pre.1"
 authors = ["Martin Tomasi <martin.tomasi@gmail.com>"]
 edition = "2021"
 description = "Runs yt-dlp and parses its JSON output."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,10 +25,8 @@ reqwest = { version = "0.11", optional = true, features = ["json"], default-feat
 
 [dev-dependencies]
 env_logger = "0.10"
-
-[dev-dependencies.tokio]
-version = "1"
-features = ["rt", "rt-multi-thread", "macros"]
+tempfile = "3.7.1"
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
 
 [[example]]
 name = "async"

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 it does support `yt-dlp`, which has diverged from `youtube-dl` in some ways, but sees a lot more development.
 
 Runs yt-dlp and parses its JSON output. Example:
+
 ```rust
 use youtube_dl::YoutubeDl;
 
@@ -18,6 +19,7 @@ println!("Video title: {}", title);
 ```
 
 Or, if you want to it to run asynchronously (enable the feature `tokio`):
+
 ```rust
 let output = YoutubeDl::new("https://www.youtube.com/watch?v=VFbhKZFzbzk")
     .socket_timeout("15")
@@ -27,3 +29,8 @@ let title = output.into_single_video().unwrap().title;
 println!("Video title: {}", title);
 Ok(())
 ```
+
+## Feature flags
+
+- **tokio**: Enables the `async` variants of the `run`, `run_raw` and `download_to` methods.
+- **downloader-native-tls** / **downloader-rustls-tls**: Enables the `download_yt_dlp` method and `YoutubeDlFetcher` struct to download the `yt-dlp` executable with the given TLS backend used for reqwest.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -933,8 +933,14 @@ mod tests {
 
     #[test]
     fn test_download_to_destination() {
+        let dir = tempfile::tempdir().unwrap();
+
         YoutubeDl::new("https://www.youtube.com/watch?v=q6EoRBvdVPQ")
-            .download_to(".")
+            .download_to(&dir)
             .unwrap();
+
+        let files: Vec<_> = std::fs::read_dir(&dir).unwrap().collect();
+        assert_eq!(1, files.len());
+        assert!(files[0].as_ref().unwrap().path().is_file());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -567,8 +567,6 @@ impl YoutubeDl {
 
         args.push("-P");
         args.push(folder);
-        args.push("-o");
-        args.push("file.%(ext)s");
         args.push("--no-simulate");
         args.push("--no-progress");
         args.push(&self.url);
@@ -773,40 +771,23 @@ impl YoutubeDl {
         }
     }
 
-    fn process_download_output(&self, destination: impl AsRef<Path>) -> Result<PathBuf, Error> {
-        use std::fs;
-
-        fs::read_dir(destination)?
-            .filter_map(|e| e.ok())
-            .find(|e| e.path().file_stem() == Some("file".as_ref()))
-            .ok_or(Error::Io(std::io::Error::new(
-                std::io::ErrorKind::NotFound,
-                "file not found",
-            )))
-            .map(|e| e.path())
-    }
-
     /// Download the file to the specified destination folder.
-    /// If the output contains a line that indicates the filename of the output,
-    /// it returns the path to that file.
-    pub fn download_to(&self, folder: impl AsRef<Path>) -> Result<PathBuf, Error> {
+    pub fn download_to(&self, folder: impl AsRef<Path>) -> Result<(), Error> {
         let folder_str = folder.as_ref().to_string_lossy();
         let args = self.process_download_args(&folder_str);
         self.run_process(args)?;
 
-        self.process_download_output(folder)
+        Ok(())
     }
 
     /// Download the file to the specified destination folder asynchronously.
-    /// If the output contains a line that indicates the filename of the output,
-    /// it returns the path to that file.
     #[cfg(feature = "tokio")]
-    pub async fn download_to_async(&self, folder: impl AsRef<Path>) -> Result<PathBuf, Error> {
+    pub async fn download_to_async(&self, folder: impl AsRef<Path>) -> Result<(), Error> {
         let folder_str = folder.as_ref().to_string_lossy();
         let args = self.process_download_args(&folder_str);
         self.run_process_async(args).await?;
 
-        self.process_download_output(folder)
+        Ok(())
     }
 }
 
@@ -952,10 +933,8 @@ mod tests {
 
     #[test]
     fn test_download_to_destination() {
-        let file = YoutubeDl::new("https://www.youtube.com/watch?v=q6EoRBvdVPQ")
+        YoutubeDl::new("https://www.youtube.com/watch?v=q6EoRBvdVPQ")
             .download_to(".")
             .unwrap();
-
-        assert!(file.is_file());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -398,7 +398,6 @@ impl YoutubeDl {
     /// Specify whether to download videos, instead of just listing them.
     ///
     /// Note that no progress will be logged or emitted.
-
     pub fn download(&mut self, download: bool) -> &mut Self {
         self.download = download;
         self
@@ -903,7 +902,7 @@ mod tests {
         let file = YoutubeDl::new("https://www.youtube.com/watch?v=q6EoRBvdVPQ")
             .download_to(".")
             .unwrap();
-        dbg!(&file);
+
         assert!(file.is_file());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -260,7 +260,6 @@ pub struct YoutubeDl {
     date_after: Option<String>,
     date: Option<String>,
     extract_audio: bool,
-    download: bool,
     playlist_items: Option<String>,
     extra_args: Vec<String>,
     output_template: Option<String>,
@@ -290,7 +289,6 @@ impl YoutubeDl {
             date_before: None,
             playlist_reverse: false,
             extract_audio: false,
-            download: false,
             playlist_items: None,
             extra_args: Vec::new(),
             output_template: None,
@@ -395,14 +393,6 @@ impl YoutubeDl {
     /// Set the `--extract-audio` command line flag.
     pub fn extract_audio(&mut self, extract_audio: bool) -> &mut Self {
         self.extract_audio = extract_audio;
-        self
-    }
-
-    /// Specify whether to download videos, instead of just listing them.
-    ///
-    /// Note that no progress will be logged or emitted.
-    pub fn download(&mut self, download: bool) -> &mut Self {
-        self.download = download;
         self
     }
 
@@ -550,12 +540,6 @@ impl YoutubeDl {
         }
 
         args.push("-J");
-
-        if self.download {
-            args.push("--no-simulate");
-            args.push("--no-progress");
-        }
-
         args.push(&self.url);
         log::debug!("youtube-dl arguments: {:?}", args);
 
@@ -898,15 +882,11 @@ mod tests {
 
     fn test_download_with_yt_dlp() {
         // yee
-        let output = YoutubeDl::new("https://www.youtube.com/watch?v=q6EoRBvdVPQ")
-            .download(true)
+        YoutubeDl::new("https://www.youtube.com/watch?v=q6EoRBvdVPQ")
             .debug(true)
             .output_template("yee")
-            .run()
-            .unwrap()
-            .into_single_video()
+            .download_to(".")
             .unwrap();
-        assert_eq!(output.id, "q6EoRBvdVPQ");
         assert!(Path::new("yee.webm").is_file() || Path::new("yee").is_file());
         let _ = std::fs::remove_file("yee.webm");
         let _ = std::fs::remove_file("yee");


### PR DESCRIPTION
- feat: Add new methods `download_to` and `download_to_async` to just download the video(s) to a destination.
- feat: Add new methods `run_raw` and `run_raw_async` to get the JSON output as `serde_json::Value`
- BREAKING CHANGE: Removed `download()` method on `YoutubeDl`, replaced with `download_to()` and `download_to_async()`