### PR TITLE
Added additional flags (cookies from browser, max downloads)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -262,6 +262,7 @@ pub struct YoutubeDl {
     date: Option<String>,
     extract_audio: bool,
     playlist_items: Option<String>,
+    max_downloads: Option<String>,
     extra_args: Vec<String>,
     output_template: Option<String>,
     output_directory: Option<String>,
@@ -292,6 +293,7 @@ impl YoutubeDl {
             playlist_reverse: false,
             extract_audio: false,
             playlist_items: None,
+            max_downloads: None,
             extra_args: Vec::new(),
             output_template: None,
             output_directory: None,
@@ -385,7 +387,7 @@ impl YoutubeDl {
         self
     }
 
-    /// Specify a file with cookies in Netscape cookie format.
+    /// Set the `--cookies-from-browser` command line flag.
     pub fn cookies_from_browser<S: Into<String>>(&mut self, browser_name: S) -> &mut Self {
         self.cookies_from_browser = Some(browser_name.into());
         self
@@ -407,6 +409,12 @@ impl YoutubeDl {
     /// Set the `--playlist-items` command line flag.
     pub fn playlist_items(&mut self, index: u32) -> &mut Self {
         self.playlist_items = Some(index.to_string());
+        self
+    }
+
+    /// Set the `--max-downloads` command line flag.
+    pub fn max_downloads(&mut self, max_downloads: u32) -> &mut Self {
+        self.max_downloads = Some(max_downloads.to_string());
         self
     }
 
@@ -506,6 +514,11 @@ impl YoutubeDl {
         if let Some(playlist_items) = &self.playlist_items {
             args.push("--playlist-items");
             args.push(playlist_items);
+        }
+
+        if let Some(max_downloads) = &self.max_downloads {
+            args.push("--max-downloads");
+            args.push(max_downloads);
         }
 
         if let Some(output_template) = &self.output_template {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -251,6 +251,7 @@ pub struct YoutubeDl {
     all_formats: bool,
     auth: Option<(String, String)>,
     cookies: Option<String>,
+    cookies_from_browser: Option<String>,
     user_agent: Option<String>,
     referer: Option<String>,
     url: String,
@@ -281,6 +282,7 @@ impl YoutubeDl {
             all_formats: false,
             auth: None,
             cookies: None,
+            cookies_from_browser: None,
             user_agent: None,
             referer: None,
             process_timeout: None,
@@ -383,6 +385,12 @@ impl YoutubeDl {
         self
     }
 
+    /// Specify a file with cookies in Netscape cookie format.
+    pub fn cookies_from_browser<S: Into<String>>(&mut self, browser_name: S) -> &mut Self {
+        self.cookies_from_browser = Some(browser_name.into());
+        self
+    }
+
     /// Set a process-level timeout for youtube-dl. (this controls the maximum overall duration
     /// the process may take, when it times out, `Error::ProcessTimeout` is returned)
     pub fn process_timeout(&mut self, timeout: Duration) -> &mut Self {
@@ -474,6 +482,11 @@ impl YoutubeDl {
         if let Some(cookie_path) = &self.cookies {
             args.push("--cookies");
             args.push(cookie_path);
+        }
+
+        if let Some(browser_name) = &self.cookies_from_browser {
+            args.push("--cookies-from-browser");
+            args.push(browser_name);
         }
 
         if let Some(user_agent) = &self.user_agent {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -388,8 +388,32 @@ impl YoutubeDl {
     }
 
     /// Set the `--cookies-from-browser` command line flag.
-    pub fn cookies_from_browser<S: Into<String>>(&mut self, browser_name: S) -> &mut Self {
-        self.cookies_from_browser = Some(browser_name.into());
+    pub fn cookies_from_browser<S: Into<String>>(
+        &mut self,
+        browser_name: S,
+        browser_keyring: Option<S>,
+        browser_profile: Option<S>,
+        browser_container: Option<S>,
+    ) -> &mut Self {
+        self.cookies_from_browser = Some(format!(
+            "{}{}{}{}",
+            browser_name.into(),
+            if let Some(keyring) = browser_keyring {
+                format!("+{}", keyring.into())
+            } else {
+                String::from("")
+            },
+            if let Some(profile) = browser_profile {
+                format!(":{}", profile.into())
+            } else {
+                String::from("")
+            },
+            if let Some(container) = browser_container {
+                format!("::{}", container.into())
+            } else {
+                String::from("")
+            }
+        ));
         self
     }
 
@@ -492,9 +516,9 @@ impl YoutubeDl {
             args.push(cookie_path);
         }
 
-        if let Some(browser_name) = &self.cookies_from_browser {
+        if let Some(cookies_from_browser) = &self.cookies_from_browser {
             args.push("--cookies-from-browser");
-            args.push(browser_name);
+            args.push(cookies_from_browser);
         }
 
         if let Some(user_agent) = &self.user_agent {


### PR DESCRIPTION
Added support for the following option flags during build :
- `--cookies-from-browser BROWSER[+KEYRING][:PROFILE][::CONTAINER]`
- `--max-downloads NUMBER`

These are just convenience methods for providing better type checking for parameters and help formatting values correctly.

> This is one of my first few PRs on all GitHub, so don't hesitate to tell me if anything could have been done better, and thanks for the work you've already done on the lib !

The `--cookies-from-browser` introduces a new way of interacting with the lib with optional parameters that are not present in other `YoutubeDl` methods, and will require users to explicitly pass `None` to parameters not needed and wrap needed values in `Some()`, could add more complete documentation for the function to explicit this point if needed.

To clarify the goal of this implementation, requiring the user to pass an already formatted `String` respecting the format `BROWSER[+KEYRING][:PROFILE][::CONTAINER]` required by `yt-dlp` would be needless as it would only be a wrapper around `extra_arg` that would stay just as prone to error, and other implementations using structs and traits would have added too much to the global architecture of the lib and potential future overhead, so thanks to optional parameters, the logic has been kept straightforward and contained inside the function.