### PR TITLE
Added support for MacOS

### DIFF
--- a/src/downloader.rs
+++ b/src/downloader.rs
@@ -9,6 +9,8 @@ use tokio::{
 
 const FILE_NAME: &str = if cfg!(target_os = "windows") {
     "yt-dlp.exe"
+} else if cfg!(target_os = "macos") {
+    "yt-dlp_macos"
 } else {
     "yt-dlp"
 };


### PR DESCRIPTION
Previously youtube-dl-rs wasn't working for MacOS, because the MacOS executable filename wasn't downloaded from the yt-dlp latest release, after this PR, if youtube-dl-rs is running on MacOS the, `yt-dlp_macos` will get downloaded ..